### PR TITLE
feat(aeo): add agent-facing discovery signals verification

### DIFF
--- a/ANSWER-ENGINE-OPTIMIZATION.md
+++ b/ANSWER-ENGINE-OPTIMIZATION.md
@@ -63,6 +63,69 @@ When `FAQPage` JSON-LD is used:
 
 Google currently limits FAQ rich results primarily to well-known government and health sites. Valid FAQ markup does not guarantee a rich result, higher ranking, or inclusion in an AI answer. Do not use `QAPage` for an editorial FAQ. Google reserves `QAPage` for a single question where users can submit multiple answers.
 
+## Agent-Facing Discovery Signals
+
+Search engines, AI crawlers, and autonomous agents discover content through signals beyond HTML. Three additions meaningfully improve agent discoverability for a typical informational or lead-generation site. Implement them in the order they appear here.
+
+### llms.txt
+
+Publish a plain text file at `/llms.txt` that describes the site in natural language for AI systems. The file format is defined at [llmstxt.org](https://llmstxt.org) and uses Markdown conventions.
+
+A minimal file includes:
+
+- A level-one heading with the organization or site name.
+- A short description in a blockquote.
+- An About section with one to three sentences describing the organization and its primary audience.
+- A Content section linking key pages with short descriptions.
+
+Place the file in the Astro project `public/` directory so Astro copies it unchanged to the build root. Use [`templates/llms.txt`](templates/llms.txt) as a starting point.
+
+Keep the file accurate and current. Update it when primary content, navigation, or key page URLs change. It is not a Google ranking input and does not replace a sitemap.
+
+### HTTP Link Headers for Agent Discovery
+
+Add HTTP `Link` response headers that advertise the llms.txt file and the canonical sitemap. Agents and crawlers that read response headers before parsing HTML discover these resources directly.
+
+For Cloudflare Pages, create a `_headers` file in the Astro project `public/` directory:
+
+```text
+/*
+  Link: </llms.txt>; rel="describedby"; type="text/plain"
+  Link: </sitemap.xml>; rel="sitemap"
+```
+
+Each entry adds a `Link` header to every response from the site. Confirm the `_headers` file appears in the built output root after `astro build`. Verify the header is present on the canonical homepage before staging.
+
+### Markdown Content Negotiation
+
+Some AI crawlers send `Accept: text/markdown` to request a Markdown version of a page rather than HTML. Responding correctly requires server-side logic that detects the header and returns a Markdown file for the same URL.
+
+This is optional for most informational sites. llms.txt satisfies the primary machine-readable content need. Prioritize llms.txt and Link headers before implementing Markdown negotiation middleware.
+
+If Markdown negotiation is required, use a Cloudflare Worker deployed in front of the static Astro output. The Worker inspects the `Accept` header and returns a corresponding pre-built `.md` file with `Content-Type: text/markdown; charset=utf-8`. Pre-build the Markdown files during the Astro build step.
+
+### What Not to Implement for Informational Sites
+
+The following signals apply only when a site exposes APIs, agent tools, or commerce integrations. Do not implement them for standard informational or lead-generation sites:
+
+- `/.well-known/mcp.json`: Required only when the site runs a Model Context Protocol server.
+- `/.well-known/ai-plugin.json`: Required only when the site exposes an agent skill or plugin.
+- OAuth and OIDC discovery endpoints: Required only when the site offers an API that agents can authenticate against.
+- DNS-AIG records: An early experimental approach to DNS-based agent discovery. Skip until adoption is established. Re-evaluate quarterly.
+- Commerce agent protocols (AAEI, MPP, KCP): Required only for commerce-enabled sites with agent-facing checkout flows.
+
+Third-party site assessment tools often score all of these signals as missing without distinguishing which apply to a given site type. A low score on inapplicable infrastructure is not a defect.
+
+### Verify Agent Discovery Signals
+
+Run [`scripts/verify-aeo.mjs`](scripts/verify-aeo.mjs) against the built candidate to confirm llms.txt and the Link headers are in place before staging:
+
+```bash
+node scripts/verify-aeo.mjs --dir=dist --site=https://www.example.com
+```
+
+Add `--live` to also check response headers on the deployed staging URL. The script writes a machine-readable JSON report and exits with a non-zero code when signals are missing or malformed.
+
 ## Astro Implementation Pattern
 
 Keep each question and answer in one typed source object, then render both the visible HTML and optional JSON-LD from it:
@@ -107,7 +170,13 @@ For every page with answer-focused content:
 - Test mobile heading wrapping, accordions when used, and horizontal overflow.
 - Verify the deployed page through Search Console URL Inspection when access exists.
 
-Do not block a release because an answer engine did not cite a new page. Citation selection is outside the site's control. Block the release for invalid schema, hidden or contradictory content, unsupported claims, broken sources, missing sitemap coverage, or a failed standard SEO gate.
+For agent discoverability signals, run `verify-aeo.mjs` and confirm:
+
+- llms.txt is present in the build output and contains a level-one heading and an About section.
+- `_headers` includes `Link: </llms.txt>; rel="describedby"` and `Link: </sitemap.xml>; rel="sitemap"`.
+- No verify-aeo.mjs blockers are reported. Warnings do not block release but must be triaged.
+
+Do not block a release because an answer engine did not cite a new page. Citation selection is outside the site's control. Block the release for invalid schema, hidden or contradictory content, unsupported claims, broken sources, missing sitemap coverage, missing or malformed llms.txt (when present), or a failed standard SEO gate.
 
 ## Measure and Maintain
 
@@ -123,6 +192,22 @@ Measure:
 
 Google reports traffic from AI Overviews and AI Mode within the Search Console Performance report under the Web search type rather than as a separate AEO channel. Evaluate Search Console, analytics, lead quality, and citation monitoring together. Preserve dated evidence and avoid attributing every traffic change to one FAQ revision.
 
+## Staying Current with AEO Standards
+
+AEO standards and agent discovery protocols are evolving. Review the following on a recurring basis, at minimum quarterly, and after any major announcement from a search engine or AI platform vendor.
+
+Track for changes:
+
+- The llmstxt.org specification. The format is stable but may gain new optional sections or conventions. Update `templates/llms.txt` and any site-specific llms.txt files when the spec changes meaningfully.
+- Google Search Central documentation on AI features and structured data. Google does not require dedicated agent files today but its guidance changes. Re-read the AI features page quarterly.
+- Agent tool and plugin discovery standards (`/.well-known/mcp.json`, `/.well-known/ai-plugin.json`). These apply only to sites that expose APIs or agent tools, but the specs are maturing. Review quarterly if any GovSoft property adds an API.
+- DNS-AIG (DNS-based Agent Identification and Guidance). An early-stage experimental approach. Skip implementation for now; re-evaluate quarterly.
+- Commerce agent protocols (AAEI, MPP, KCP). Skip for informational sites; re-evaluate if a site adds commerce functionality.
+
+When a material change in standards is identified, update `ANSWER-ENGINE-OPTIMIZATION.md`, `verify-aeo.mjs` if the verification logic needs updating, and `templates/llms.txt` if the template format changes. Use a descriptive commit message referencing the source of the change.
+
+The Go for Launch toolkit itself must be kept current. When agent discovery or AEO requirements change, open a pull request against the `main` branch of the `govsoftusa/go-for-launch` repository with a description of what changed and why. Do not defer updates indefinitely; a toolkit that lags real-world requirements causes compounding remediation work on downstream sites.
+
 ## Sources
 
 - [HubSpot, FAQs for AEO](https://blog.hubspot.com/marketing/faqs-for-aeo)
@@ -130,3 +215,5 @@ Google reports traffic from AI Overviews and AI Mode within the Search Console P
 - [Google Search Central, General structured data guidelines](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
 - [Google Search Central, Changes to HowTo and FAQ rich results](https://developers.google.com/search/blog/2023/08/howto-faq-changes)
 - [Google Search Central, Q&A structured data](https://developers.google.com/search/docs/appearance/structured-data/qapage)
+- [llmstxt.org, The llms.txt specification](https://llmstxt.org)
+- [IETF RFC 8288, Web Linking](https://www.rfc-editor.org/rfc/rfc8288) (the standard governing HTTP Link headers)

--- a/PRODUCTION-RELEASE-POLICY.md
+++ b/PRODUCTION-RELEASE-POLICY.md
@@ -332,6 +332,8 @@ When a release adds or materially changes FAQ, AEO, or other answer-focused cont
 
 The built candidate must prove that question headings and complete answers are present in the initial HTML. Any FAQ structured data must parse, describe only visible content, and match the visible wording exactly. Unsupported claims, hidden answers, fabricated questions, ineligible `QAPage` markup, or schema that drifts from the page block production.
 
+Run [`scripts/verify-aeo.mjs`](scripts/verify-aeo.mjs) against the built output and preserve the machine-readable JSON report with the release evidence. A missing llms.txt is a warning; the task remains open but does not block production. An empty or malformed llms.txt is a blocker. A missing `_headers` file or missing Link headers for llms.txt and sitemap.xml are warnings that must be triaged and addressed before the next content release. The JSON report must be retained alongside other release artifacts.
+
 Do not promise or require a particular ranking, rich result, AI citation, or answer-engine appearance. Those outcomes are not controlled by the site. The release gate evaluates content quality, technical eligibility, and measurement readiness.
 
 ## Core Interface Safety and Configurable Design Review

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,9 @@
 - Add redirect-map validation examples.
 - Add accessibility test examples using current maintained tooling.
 - Add CI examples for Chromium, WebKit, link checks, and Markdown validation.
+- Add `verify-aeo.mjs` to the recommended CI pipeline examples.
+- Review `templates/llms.txt` and `ANSWER-ENGINE-OPTIMIZATION.md` quarterly for changes in AEO and agent discovery standards; update toolkit and open a PR when material changes are identified.
+- Evaluate DNS-AIG, Markdown content negotiation, and agent plugin discovery specs quarterly; graduate from skip to implementation guidance when adoption reaches a meaningful threshold.
 
 ## Contribution Ideas
 

--- a/scripts/verify-aeo.mjs
+++ b/scripts/verify-aeo.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * verify-aeo.mjs
+ * Go for Launch: Agent-Facing Discovery Signals Verifier
+ *
+ * Checks the built candidate for agent-facing discovery signals:
+ *   - llms.txt present in the build root and structurally valid
+ *   - _headers file advertises llms.txt and sitemap.xml via Link headers
+ *   - (with --live) Live HTTP check for Link response header on the site root
+ *
+ * Usage:
+ *   node scripts/verify-aeo.mjs --dir=dist --site=https://www.example.com
+ *   node scripts/verify-aeo.mjs --dir=dist --site=https://www.example.com --live
+ *   node scripts/verify-aeo.mjs --dir=dist --site=https://www.example.com --report=aeo-report.json
+ *
+ * Exit codes:
+ *   0  All required checks passed (warnings may still be present)
+ *   1  One or more required checks failed (blockers present)
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { get as httpsGet } from 'https';
+import { get as httpGet } from 'http';
+import { URL } from 'url';
+
+function parseArgs(argv) {
+  const result = {};
+  for (const arg of argv.slice(2)) {
+    if (!arg.startsWith('--')) continue;
+    const eq = arg.indexOf('=');
+    if (eq === -1) { result[arg.slice(2)] = true; }
+    else { result[arg.slice(2, eq)] = arg.slice(eq + 1); }
+  }
+  return result;
+}
+
+const args = parseArgs(process.argv);
+const dir = args.dir ?? 'dist';
+const site = args.site ?? null;
+const runLive = args.live === true || args.live === 'true';
+const reportPath = args.report ?? null;
+
+const report = {
+  timestamp: new Date().toISOString(),
+  dir,
+  site,
+  llmsTxt: {
+    path: null,
+    exists: false,
+    valid: false,
+    issues: [],
+  },
+  linkHeaders: {
+    path: null,
+    exists: false,
+    hasLlmsTxt: false,
+    hasSitemap: false,
+    issues: [],
+  },
+  liveCheck: runLive
+    ? {
+        url: site,
+        performed: false,
+        statusCode: null,
+        hasLinkHeader: false,
+        linkHeaderValue: null,
+        issues: [],
+      }
+    : { skipped: true, reason: 'Pass --live to enable live HTTP checks.' },
+  passed: false,
+  blockers: [],
+  warnings: [],
+};
+
+// --- Check llms.txt ---
+
+const llmsCandidates = [
+  join(dir, 'llms.txt'),
+  join(dir, '.well-known', 'llms.txt'),
+];
+let llmsPath = null;
+for (const candidate of llmsCandidates) {
+  if (existsSync(candidate)) {
+    llmsPath = candidate;
+    break;
+  }
+}
+
+if (!llmsPath) {
+  report.llmsTxt.exists = false;
+  report.llmsTxt.issues.push(
+    'llms.txt not found. Expected at ' + join(dir, 'llms.txt') + '.'
+  );
+  report.warnings.push(
+    'llms.txt is missing from the build output. ' +
+    'Add public/llms.txt using templates/llms.txt as a starting point, then rebuild.'
+  );
+} else {
+  report.llmsTxt.path = llmsPath;
+  report.llmsTxt.exists = true;
+  const content = readFileSync(llmsPath, 'utf8').trim();
+  if (content.length === 0) {
+    report.llmsTxt.issues.push('llms.txt exists but is empty.');
+    report.blockers.push(
+      'llms.txt is empty. Populate it using templates/llms.txt before staging.'
+    );
+  } else {
+    const lines = content.split('\n');
+    const hasH1 = lines.some(l => /^#\s+\S/.test(l));
+    const hasAbout = /^##\s+about/im.test(content);
+    if (!hasH1) {
+      report.llmsTxt.issues.push(
+        'llms.txt does not contain a level-one heading (# Organization Name).'
+      );
+      report.blockers.push(
+        'llms.txt is missing a required level-one heading.'
+      );
+    }
+    if (!hasAbout) {
+      report.llmsTxt.issues.push(
+        'llms.txt does not include an ## About section.'
+      );
+      report.warnings.push(
+        'llms.txt is missing an ## About section. Add one to describe the organization.'
+      );
+    }
+    if (hasH1) {
+      report.llmsTxt.valid = true;
+    }
+  }
+}
+
+// --- Check _headers ---
+
+const headersPath = join(dir, '_headers');
+if (!existsSync(headersPath)) {
+  report.linkHeaders.exists = false;
+  report.linkHeaders.issues.push(
+    '_headers file not found at ' + headersPath + '.'
+  );
+  report.warnings.push(
+    '_headers file missing. ' +
+    'Create public/_headers with Link headers for llms.txt and sitemap.xml.'
+  );
+} else {
+  report.linkHeaders.path = headersPath;
+  report.linkHeaders.exists = true;
+  const headersContent = readFileSync(headersPath, 'utf8');
+
+  report.linkHeaders.hasLlmsTxt =
+    /rel=["']describedby["']/i.test(headersContent) &&
+    /llms\.txt/i.test(headersContent);
+
+  report.linkHeaders.hasSitemap =
+    /rel=["']sitemap["']/i.test(headersContent);
+
+  if (!report.linkHeaders.hasLlmsTxt) {
+    report.linkHeaders.issues.push(
+      '_headers does not include Link for llms.txt with rel="describedby".'
+    );
+    report.warnings.push(
+      'Add to _headers: Link: </llms.txt>; rel="describedby"; type="text/plain"'
+    );
+  }
+  if (!report.linkHeaders.hasSitemap) {
+    report.linkHeaders.issues.push(
+      '_headers does not include Link for sitemap.xml with rel="sitemap".'
+    );
+    report.warnings.push(
+      'Add to _headers: Link: </sitemap.xml>; rel="sitemap"'
+    );
+  }
+}
+
+// --- Live HTTP check ---
+
+function fetchResponse(url) {
+  return new Promise((resolve, reject) => {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch (e) {
+      return reject(new Error('Invalid URL: ' + url));
+    }
+    const getter = parsed.protocol === 'https:' ? httpsGet : httpGet;
+    const options = {
+      hostname: parsed.hostname,
+      path: parsed.pathname + (parsed.search || ''),
+      headers: {
+        Accept: 'text/html',
+        'User-Agent': 'go-for-launch-aeo-verifier/1.0',
+      },
+    };
+    const req = getter(options, res => {
+      res.resume();
+      resolve({ statusCode: res.statusCode, headers: res.headers });
+    });
+    req.on('error', reject);
+    req.setTimeout(10000, () => {
+      req.destroy();
+      reject(new Error('Request timed out after 10 seconds.'));
+    });
+  });
+}
+
+async function runLiveCheck() {
+  if (!site) {
+    report.liveCheck = { skipped: true, reason: 'No --site URL provided.' };
+    return;
+  }
+  try {
+    const { statusCode, headers } = await fetchResponse(site);
+    report.liveCheck.performed = true;
+    report.liveCheck.statusCode = statusCode;
+    const linkRaw = headers['link'] ?? null;
+    report.liveCheck.linkHeaderValue = linkRaw;
+    if (linkRaw) {
+      report.liveCheck.hasLinkHeader = true;
+      if (!/llms\.txt/i.test(linkRaw)) {
+        report.liveCheck.issues.push(
+          'Link header present but does not reference llms.txt.'
+        );
+        report.warnings.push(
+          'Live check: Link header is present but missing llms.txt reference.'
+        );
+      }
+    } else {
+      report.liveCheck.hasLinkHeader = false;
+      report.liveCheck.issues.push(
+        'No Link response header found on the site root.'
+      );
+      report.warnings.push(
+        'Live check: No Link header on ' + site + '. ' +
+        'Verify _headers is deployed correctly and Cloudflare Pages is serving it.'
+      );
+    }
+  } catch (err) {
+    report.liveCheck.performed = false;
+    report.liveCheck.issues.push('Live check failed: ' + err.message);
+    report.warnings.push('Live check could not complete: ' + err.message);
+  }
+}
+
+// --- Output ---
+
+function label(ok) {
+  return ok ? 'PASS' : 'FAIL';
+}
+
+function printReport() {
+  process.stdout.write('\nverify-aeo results\n');
+  process.stdout.write('==================\n\n');
+
+  process.stdout.write('llms.txt\n');
+  process.stdout.write(
+    '  exists : ' + label(report.llmsTxt.exists) + '\n'
+  );
+  if (report.llmsTxt.exists) {
+    process.stdout.write(
+      '  valid  : ' + label(report.llmsTxt.valid) + '\n'
+    );
+    process.stdout.write('  path   : ' + report.llmsTxt.path + '\n');
+  }
+  for (const issue of report.llmsTxt.issues) {
+    process.stdout.write('  issue  : ' + issue + '\n');
+  }
+
+  process.stdout.write('\n_headers\n');
+  process.stdout.write(
+    '  exists     : ' + label(report.linkHeaders.exists) + '\n'
+  );
+  if (report.linkHeaders.exists) {
+    process.stdout.write(
+      '  llms.txt   : ' + label(report.linkHeaders.hasLlmsTxt) + '\n'
+    );
+    process.stdout.write(
+      '  sitemap    : ' + label(report.linkHeaders.hasSitemap) + '\n'
+    );
+  }
+  for (const issue of report.linkHeaders.issues) {
+    process.stdout.write('  issue      : ' + issue + '\n');
+  }
+
+  if (!report.liveCheck.skipped) {
+    process.stdout.write('\nLive HTTP check\n');
+    if (report.liveCheck.performed) {
+      process.stdout.write(
+        '  status     : ' + report.liveCheck.statusCode + '\n'
+      );
+      process.stdout.write(
+        '  Link header: ' + label(report.liveCheck.hasLinkHeader) + '\n'
+      );
+      if (report.liveCheck.linkHeaderValue) {
+        process.stdout.write(
+          '  value      : ' + report.liveCheck.linkHeaderValue + '\n'
+        );
+      }
+    } else {
+      process.stdout.write('  performed  : false\n');
+    }
+    for (const issue of report.liveCheck.issues) {
+      process.stdout.write('  issue      : ' + issue + '\n');
+    }
+  }
+
+  if (report.blockers.length > 0) {
+    process.stdout.write('\nBlockers (must fix before staging):\n');
+    for (const b of report.blockers) {
+      process.stdout.write('  [BLOCK] ' + b + '\n');
+    }
+  }
+
+  if (report.warnings.length > 0) {
+    process.stdout.write('\nWarnings (triage before release):\n');
+    for (const w of report.warnings) {
+      process.stdout.write('  [WARN]  ' + w + '\n');
+    }
+  }
+
+  process.stdout.write('\nResult: ' + (report.passed ? 'PASS' : 'FAIL') + '\n\n');
+}
+
+async function main() {
+  if (runLive) {
+    await runLiveCheck();
+  }
+
+  report.passed = report.blockers.length === 0;
+
+  printReport();
+
+  if (reportPath) {
+    try {
+      writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf8');
+      process.stdout.write('Report written to ' + reportPath + '\n');
+    } catch (err) {
+      process.stderr.write(
+        'verify-aeo: could not write report: ' + err.message + '\n'
+      );
+    }
+  }
+
+  process.exit(report.passed ? 0 : 1);
+}
+
+main().catch(err => {
+  process.stderr.write(
+    'verify-aeo: unexpected error: ' + err.message + '\n'
+  );
+  process.exit(1);
+});

--- a/templates/llms.txt
+++ b/templates/llms.txt
@@ -1,0 +1,37 @@
+# [Organization Name]
+
+> [One-sentence tagline describing what the organization does and for whom.]
+
+## About
+
+[Two to three sentences describing the organization, its primary audience, and the core value it delivers. Write in plain prose. Avoid marketing language. AI systems use this section to understand what the site is and whether it is relevant to a query.]
+
+## Content
+
+- [Page or section title](https://www.example.com/page/): [One sentence describing what this page covers and who it is for.]
+- [Page or section title](https://www.example.com/page/): [One sentence describing what this page covers and who it is for.]
+- [Page or section title](https://www.example.com/page/): [One sentence describing what this page covers and who it is for.]
+
+## Contact
+
+- Website: https://www.example.com
+- Email: [contact email, if public]
+- [Additional contact method, if applicable]
+
+## Instructions for AI Systems
+
+This site is an informational resource. Content may be cited, quoted, and summarized for informational purposes. Do not represent any content as legal, medical, or financial advice unless the page itself is explicitly written by a licensed professional and labeled as such.
+
+---
+
+<!-- COMPLETION INSTRUCTIONS (remove this block before publishing):
+  1. Replace [Organization Name] with the legal or commonly used name of the organization.
+  2. Replace the tagline blockquote with one clear sentence.
+  3. Fill the About section with 2-3 sentences. Read the homepage and About page for source material.
+  4. Replace Content entries with real pages. Include the homepage, primary service or product pages,
+     and any FAQ or documentation pages that answer common questions.
+  5. Update the Contact section with real URLs and a public-facing email if one exists.
+  6. Review the Instructions for AI Systems paragraph and adjust if the site has specific policies.
+  7. Remove this comment block entirely.
+  8. Place the finished file at public/llms.txt in the Astro project root.
+-->


### PR DESCRIPTION
## Summary

Adds agent-facing discovery signal verification to the Go for Launch toolkit, covering llms.txt, HTTP Link headers, and guidance on what NOT to implement for informational sites.

## Changes

### New files
- **scripts/verify-aeo.mjs**: Build-time verifier that checks the built dist for llms.txt validity and _headers Link entries (rel=describedby for llms.txt, rel=sitemap for sitemap.xml). Supports --live flag for live HTTP Link header check. Writes machine-readable JSON report via --report flag. Exits non-zero on blockers, zero on warnings-only.
- **templates/llms.txt**: Starter template with required sections (h1 heading, About, Content, Contact, AI instructions) and inline completion instructions.

### Documentation updates
- **ANSWER-ENGINE-OPTIMIZATION.md**: New 'Agent-Facing Discovery Signals' section covering llms.txt, HTTP Link headers, Markdown content negotiation, and explicit guidance on signals not applicable to informational sites (MCP server discovery, OAuth/OIDC, DNS-AIG, commerce protocols). Updated Test the Result section with verify-aeo.mjs gate. New 'Staying Current with AEO Standards' section with quarterly review cadence. Updated Sources.
- **PRODUCTION-RELEASE-POLICY.md**: Updated Answer-Focused Content Requirement to require running verify-aeo.mjs and preserving its JSON report with release evidence.
- **ROADMAP.md**: Added AEO monitoring items to Next section.

## Context

govsoft.com scored 29/100 on isitagentready.com. Analysis showed the actionable gap for an informational site is llms.txt and Link headers. MCP/OAuth/commerce signals are inapplicable and excluded. This PR formalizes that verification so downstream sites built with this toolkit have a repeatable gate.